### PR TITLE
Add new parameter basePath 

### DIFF
--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -10,7 +10,7 @@ var parse = require('./parse');
 module.exports = function (dependencyGraph, opts) {
   opts = opts || {};
   var exclude = opts.exclude || [];
-  var baseUrl = opts.baseUrl || '';
+  var basePath = opts.basePath || '';
   var overrides = dependencyGraph.pkgMeta.overrides;
 
   // Override the main property of each direct dependency.
@@ -67,7 +67,7 @@ module.exports = function (dependencyGraph, opts) {
       return;
     }
 
-    var configElement = parse(dep, name, baseUrl);
+    var configElement = parse(dep, name, basePath);
     if (configElement) {
       if (configElement.paths) {
         assign(config.paths, configElement.paths);

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -13,7 +13,7 @@ var primary = require('./primary');
  * Parse bower dependency down to one or more primary
  * js files.
  */
-module.exports = function (dep, name, baseUrl) {
+module.exports = function (dep, name, basePath) {
 
   /**
    * Fixup slashes in file paths for windows
@@ -40,7 +40,7 @@ module.exports = function (dep, name, baseUrl) {
     return configElement;
   }
 
-  function parsePaths(dep, name, baseUrl) {
+  function parsePaths(dep, name, basePath) {
     var canonicalDir = dep.canonicalDir;
     var main;
     if (dep.pkgMeta.main) {
@@ -151,7 +151,7 @@ module.exports = function (dep, name, baseUrl) {
     }
 
     /**
-     * Return a dependency path that is relative to the baseUrl
+     * Return a dependency path that is relative to the basePath
      * and has normalized slashes for Windows users
      */
     function getPath(val) {
@@ -205,12 +205,12 @@ module.exports = function (dep, name, baseUrl) {
     }
 
     /**
-     * Generate a relative path name using the baseUrl. If
-     * baseUrl was not defined then it will just use the dir
+     * Generate a relative path name using the basePath. If
+     * basePath was not defined then it will just use the dir
      * that contains the rjs config file.
      */
     function relative(filepath) {
-      return path.relative(path.join(process.cwd(), baseUrl), filepath);
+      return path.relative(path.join(process.cwd(), basePath), filepath);
     }
 
     var resolvedPaths = getResolvedPaths();
@@ -231,6 +231,6 @@ module.exports = function (dep, name, baseUrl) {
   }
 
   // Parse as paths if not package.
-  return parsePaths(dep, name, baseUrl);
+  return parsePaths(dep, name, basePath);
 
 };


### PR DESCRIPTION
Since the URL is used as a config file for require JS, there should be a basePath, that refers to the physical file instead. 
